### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # negrolockote
-Manejar todo
+instalar termuxblack
+
+wget https://github.com/Hax4us/TermuxBlack/raw/master/install.sh
+
+bash install.sh -i


### PR DESCRIPTION
29 líneas (23 sloc)  809 bytes
logo

es un repositorio no oficial mantenido por mí @ hax4us. puede consultar los paquetes disponibles en README

Instalar TermuXBlacK
Simplemente descargue el script de instalación wget https://github.com/Hax4us/TermuxBlack/raw/master/install.sh
Ahora corre bash install.sh
Paquete de instalación
apt install pkg_name

Los paquetes se agregarán según los chicos de su demanda :) (Solo abra el problema como una solicitud de paquete)
Lista de paquetes disponibles
carne-xss
trape
ssh-honeypot
pdfcrack
limón
apkmod
haxRat
msfpc
apkmod2
dreel
xerosploit